### PR TITLE
update buildsrc to ensure no fuzz in `debian/patches/fix-module-dependencies.diff`

### DIFF
--- a/buildsrc_lib/__init__.py
+++ b/buildsrc_lib/__init__.py
@@ -371,6 +371,11 @@ class Webmin(_Common):
                     elif line[0] in ["-", "+"] and old_version in line:
                         line = line.replace(old_version, new_version)
                         changed_lines += 1
+                    elif f"version={old_version}" in line:
+                        # dpkg-buildpackage will fail on "fuzz" so also update
+                        # this line in the patch file - but don't count as a
+                        # "changed line"
+                        line = line.replace(old_version, new_version)
                     fob.write(line)
         except OSError as e:
             raise WebminUpdateError(e) from e

--- a/debian/patches/fix-module-dependencies.diff
+++ b/debian/patches/fix-module-dependencies.diff
@@ -28,4 +28,4 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 -depends=mount fdisk 2.510
 +depends=mount fdisk raid 2.510
  longdesc=Configure volume groups, physical volumes and logical volumes for Linux LVM.
- version=2.402
+ version=2.510


### PR DESCRIPTION
Webmin package build was failing as `dpkg-buildpackage` applies quilt patches strictly and fails if there is "fuzz".

This update to `buildsrc` also updates the "fuzzy" line in `debian/patches/fix-module-dependencies.diff` that `dpkg-buildpackage` is choking on.